### PR TITLE
Add copyright header in python/c++ files.

### DIFF
--- a/libzim/examples.py
+++ b/libzim/examples.py
@@ -1,3 +1,22 @@
+# This file is part of python-libzim
+# (see https://github.com/libzim/python-libzim)
+#
+# Copyright (c) 2020 Juan Diego Caballero <jdc@monadical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
 from libzim import ZimArticle, ZimBlob, ZimCreator
 
 class ZimTestArticle(ZimArticle):

--- a/libzim/lib.cxx
+++ b/libzim/lib.cxx
@@ -1,3 +1,25 @@
+/*
+ * This file is part of python-libzim
+ * (see https://github.com/libzim/python-libzim)
+ *
+ * Copyright (c) 2020 Juan Diego Caballero <jdc@monadical.com>
+ * Copyright (c) 2020 Matthieu Gautier <mgautier@kymeria.fr>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
 #include <Python.h>
 #include "lib.h"
 

--- a/libzim/lib.h
+++ b/libzim/lib.h
@@ -1,4 +1,23 @@
 // -*- c++ -*-
+/*
+ * This file is part of python-libzim
+ * (see https://github.com/libzim/python-libzim)
+ *
+ * Copyright (c) 2020 Juan Diego Caballero <jdc@monadical.com>.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 #ifndef libzim_LIB_H
 #define libzim_LIB_H 1
 

--- a/libzim/libzim.pxd
+++ b/libzim/libzim.pxd
@@ -1,3 +1,22 @@
+# This file is part of python-libzim
+# (see https://github.com/libzim/python-libzim)
+#
+# Copyright (c) 2020 Juan Diego Caballero <jdc@monadical.com>
+# Copyright (c) 2020 Matthieu Gautier <mgautier@kymeria.fr>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 from libcpp.string cimport string
 from libc.stdint cimport uint32_t, uint64_t
 from libcpp cimport bool

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -1,3 +1,22 @@
+# This file is part of python-libzim
+# (see https://github.com/libzim/python-libzim)
+#
+# Copyright (c) 2020 Juan Diego Caballero <jdc@monadical.com>
+# Copyright (c) 2020 Matthieu Gautier <mgautier@kymeria.fr>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 cimport libzim
 cimport cpython.ref as cpy_ref
 from cython.operator import dereference

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     author = "Monadical SAS",
     author_email = "hello@monadical.com",
     description = ("A python-facing API for creating and interacting with ZIM files"),
-    license = "GPLv3",
+    license = "GPLv3+",
     long_description=read('README.md'),
     ext_modules = cythonize([
         Extension("libzim",  ["libzim/*.pyx","libzim/lib.cxx"],

--- a/tests/test_libzim.py
+++ b/tests/test_libzim.py
@@ -1,3 +1,21 @@
+# This file is part of python-libzim
+# (see https://github.com/libzim/python-libzim)
+#
+i# Copyright (c) 2020 Juan Diego Caballero <jdc@monadical.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
 import unittest
 import os,sys,inspect
 


### PR DESCRIPTION
Fix #23 

This also change the license from gplv3 to gplv3+.

Please @jdcaballerov @pirate, confirm you agree with this change. Especially with the change to gplv3+. We cannot do it without your agreement.

