### PR TITLE
Fixed unset mainpage in Creator

### DIFF
--- a/libzim/lib.cxx
+++ b/libzim/lib.cxx
@@ -209,7 +209,7 @@ public:
         : zim::writer::Creator(true),
           mainPage(mainPage) {}
 
-    virtual zim::writer::Url getMainUrl()
+    virtual zim::writer::Url getMainUrl() const
     {
         return zim::writer::Url('A', mainPage);
     }

--- a/tests/test_libzim.py
+++ b/tests/test_libzim.py
@@ -19,6 +19,7 @@
 import pytest
 
 from libzim.writer import Article, Blob, Creator
+from libzim.reader import File
 
 # test files https://wiki.kiwix.org/wiki/Content_in_all_languages
 
@@ -140,3 +141,21 @@ def test_check_mandatory_metadata(tmpdir):
             title="Test Zim",
         )
         assert zim_creator.mandatory_metadata_ok()
+
+
+def test_creator_params(tmpdir):
+    path = str(tmpdir / "test.zim")
+    main_page = "welcome"
+    main_page_url = f"A/{main_page}"
+    index_language = "eng"
+    with Creator(
+        path, main_page=main_page_url, index_language=index_language, min_chunk_size=2048
+    ) as zim_creator:
+        zim_creator.add_article(
+            SimpleArticle(title="Welcome", mime_type="text/html", content="", url=main_page_url)
+        )
+
+    zim = File(path)
+    assert zim.filename == path
+    assert zim.main_page_url == main_page_url
+    assert bytes(zim.get_article("/M/Language").content).decode("UTF-8") == index_language


### PR DESCRIPTION
Fixed #36 by fixing the `OverriddenZimCreator::getMainUrl` signature.