### PR TITLE
Properly dealloc creatorWrapper on close

### DIFF
--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -150,6 +150,9 @@ class Creator:
     def __exit__(self, *args):
         self.close()
 
+    def __del__(self):
+        self.close()
+
     def add_article(self, article):
         self._creatorWrapper.add_article(article)
         if not article.is_redirect():

--- a/tests/test_libzim.py
+++ b/tests/test_libzim.py
@@ -159,3 +159,28 @@ def test_creator_params(tmpdir):
     assert zim.filename == path
     assert zim.main_page_url == main_page_url
     assert bytes(zim.get_article("/M/Language").content).decode("UTF-8") == index_language
+
+
+def test_segfault_on_realloc(tmpdir):
+    """ assert that we are able to delete an unclosed Creator #31 """
+    creator = Creator(str(tmpdir / "test.zim"), "welcome", "eng", 2048)
+    del creator  # used to segfault
+    assert True
+
+
+def test_noleftbehind_empty(tmpdir):
+    """ assert that ZIM with no articles don't leave files behind #41 """
+    fname = "test_empty.zim"
+    with Creator(
+        str(tmpdir / fname), main_page="welcome", index_language="eng", min_chunk_size=2048,
+    ) as zim_creator:
+        print(zim_creator)
+
+    assert len([p for p in tmpdir.listdir() if p.basename.startswith(fname)]) == 1
+
+
+def test_double_close(tmpdir):
+    creator = Creator(str(tmpdir / "test.zim"), "welcome", "eng", 2048)
+    creator.close()
+    with pytest.raises(RuntimeError):
+        creator.close()


### PR DESCRIPTION
Fixes #41 by explicitly deleting the creatorWrapper once we've finalized it on the `Creator.close`.

Also fixes #31 by calling `close()` on `Creator` (pure-python) deletion