### PR TITLE
Various improvements

### DIFF
--- a/libzim/reader.py
+++ b/libzim/reader.py
@@ -1,4 +1,16 @@
-# flake8: noqa
+""" libzim reader module
 
+    - File to open and read ZIM files
+    - Article are returned by File on get_article() and get_article_by_id()
+    - NotFound is raised on incorrect article URL query
+
+    Usage:
+
+    with File(pathlib.Path("myfile.zim")) as zf:
+        article = zf.get_article(zf.main_page_url)
+        print(f"Article {article.title} at {article.url} is {article.content.nbytes}b")
+    """
+
+# flake8: noqa
 from .wrapper import FilePy as File, NotFound
 from .wrapper import ReadArticle as Article

--- a/libzim/reader.py
+++ b/libzim/reader.py
@@ -1,4 +1,4 @@
 # flake8: noqa
 
-from .wrapper import FilePy as File
+from .wrapper import FilePy as File, NotFound
 from .wrapper import ReadArticle as Article

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -31,6 +31,7 @@ from libcpp.memory cimport shared_ptr, make_shared, unique_ptr
 
 import datetime
 
+
 class NotFound(RuntimeError):
     pass
 
@@ -407,14 +408,13 @@ cdef class FilePy:
         return article
 
     def get_metadata(self, name):
-        """Get the file metadata.
+        """Get a metadata
         Returns
         -------
-        dict
-            A dictionary with the file metadata
+        bytes
+            Metadata article's content. Can be of any type.
         """
-        article = self.get_article(f"M/{name}")
-        return article.content
+        return bytes(self.get_article(f"M/{name}").content)
 
     def get_article_by_id(self, article_id):
         """Get a ZimFileArticle with a copy of the file article by article id.

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -29,6 +29,7 @@ from libcpp.string cimport string
 from libcpp cimport bool
 from libcpp.memory cimport shared_ptr, make_shared, unique_ptr
 
+import pathlib
 import datetime
 
 
@@ -356,14 +357,14 @@ cdef class FilePy:
     ----------
     *c_file : File
         a pointer to a C++ File object
-    _filename : str
+    _filename : pathlib.Path
         the file name of the File Reader object
     """
 
     cdef wrapper.File *c_file
     cdef object _filename
 
-    def __cinit__(self, str filename):
+    def __cinit__(self, object filename):
         """Constructs a File from full zim file path.
         Parameters
         ----------
@@ -371,8 +372,8 @@ cdef class FilePy:
             Full path to a zim file
         """
 
-        self.c_file = new wrapper.File(filename.encode('UTF-8'))
-        self._filename = self.c_file.getFilename().decode("UTF-8", "strict")
+        self.c_file = new wrapper.File(str(filename).encode('UTF-8'))
+        self._filename = pathlib.Path(self.c_file.getFilename().decode("UTF-8", "strict"))
 
     def __dealloc__(self):
         if self.c_file != NULL:

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -31,6 +31,9 @@ from libcpp.memory cimport shared_ptr, make_shared, unique_ptr
 
 import datetime
 
+class NotFound(RuntimeError):
+    pass
+
 #########################
 #         Blob          #
 #########################
@@ -392,13 +395,13 @@ cdef class FilePy:
             The Article object
         Raises
         ------
-            RuntimeError
+            NotFound
                 If an article with the provided long url is not found in the file
         """
         # Read to a zim::Article
         cdef wrapper.Article art = self.c_file.getArticleByUrl(url.encode('UTF-8'))
         if not art.good():
-            raise RuntimeError("Article not found for url")
+            raise NotFound("Article not found for url")
 
         article = ReadArticle.from_read_article(art)
         return article
@@ -413,12 +416,12 @@ cdef class FilePy:
         article = self.get_article(f"M/{name}")
         return article.content
 
-    def get_article_by_id(self, id):
+    def get_article_by_id(self, article_id):
         """Get a ZimFileArticle with a copy of the file article by article id.
 
         Parameters
         ----------
-        id : int
+        article_id : int
             The id of the article
         Returns
         -------
@@ -427,13 +430,15 @@ cdef class FilePy:
         Raises
         ------
             RuntimeError
+                If there is a problem in retrieving article (ex: id is out of bound)
+            NotFound
                 If an article with the provided id is not found in the file
         """
 
         # Read to a zim::Article
-        cdef wrapper.Article art = self.c_file.getArticle(<int> id)
+        cdef wrapper.Article art = self.c_file.getArticle(<int> article_id)
         if not art.good():
-            raise RuntimeError("Article not found for id")
+            raise NotFound("Article not found for id")
 
         article = ReadArticle.from_read_article(art)
         return article

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -335,7 +335,7 @@ cdef class ReadArticle:
         return article
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(url={self.longurl}, title=)"
+        return f"{self.__class__.__name__}(url={self.longurl}, title={self.title})"
 
 
 
@@ -575,4 +575,4 @@ cdef class FilePy:
         return dereference(search).get_matches_estimated()
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(filename={self.filename}"
+        return f"{self.__class__.__name__}(filename={self.filename})"

--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -17,7 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-
+import pathlib
 import datetime
 from collections import defaultdict
 
@@ -113,7 +113,7 @@ class Creator:
         a pointer to the C++ Creator object
     _finalized : bool
         flag if the creator was finalized
-    _filename : str
+    _filename : pathlib.Path
         Zim file path
     _main_page : str
         Zim file main page
@@ -128,8 +128,8 @@ class Creator:
     """
 
     def __init__(self, filename, main_page, index_language="eng", min_chunk_size=2048):
-        self._creatorWrapper = _Creator(filename, main_page, index_language, min_chunk_size)
-        self.filename = filename
+        self._creatorWrapper = _Creator(str(filename), main_page, index_language, min_chunk_size)
+        self.filename = pathlib.Path(filename)
         self.main_page = main_page
         self.language = index_language
         self._metadata = {}

--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -98,17 +98,6 @@ class MetadataArticle(Article):
         return Blob(self.metadata_content)
 
 
-MANDATORY_METADATA_KEYS = [
-    "Name",
-    "Title",
-    "Creator",
-    "Publisher",
-    "Date",
-    "Description",
-    "Language",
-]
-
-
 def pascalize(keyword):
     """ Converts python case to pascal case. example: long_description-> LongDescription """
     return "".join(keyword.title().split("_"))
@@ -165,13 +154,8 @@ class Creator:
         # default dict update
         self._article_counter[article.get_mime_type().strip()] += 1
 
-    def mandatory_metadata_ok(self):
-        """Flag if mandatory metadata is complete and not empty"""
-        metadata_item_ok = [k in self._metadata for k in MANDATORY_METADATA_KEYS]
-        return all(metadata_item_ok)
-
-    def update_metadata(self, **kwargs):
-        "Updates article metadata" ""
+    def update_metadata(self, **kwargs: str):
+        """ Updates Creator metadata for ZIM, supplied as keyword arguments """
         new_metadata = {pascalize(k): v for k, v in kwargs.items()}
         self._metadata.update(new_metadata)
 

--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -63,6 +63,9 @@ class Article:
     def get_data(self):
         raise NotImplementedError
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}(url={self.get_url()}, title={self.get_title()})"
+
 
 class MetadataArticle(Article):
     def __init__(self, url, metadata_content):

--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -135,7 +135,7 @@ class Creator:
         Zim file metadata
     """
 
-    def __init__(self, filename, main_page, index_language, min_chunk_size):
+    def __init__(self, filename, main_page, index_language="eng", min_chunk_size=2048):
         self._creatorWrapper = _Creator(filename, main_page, index_language, min_chunk_size)
         self.filename = filename
         self.main_page = main_page

--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -1,3 +1,16 @@
+""" libzim writer module
+    - Creator to create ZIM files
+    - Article to store ZIM articles metadata
+    - Blob to store ZIM article content
+    Usage:
+    with Creator(pathlib.Path("myfile.zim"), main_page="welcome.html") as xf:
+        article = MyArticleSubclass(
+            url="A/welcome.html",
+            title="My Title",
+            content=Blob("My content"))
+        zf.add_article(article)
+        zf.update_metadata(tags="new;demo") """
+
 # This file is part of python-libzim
 # (see https://github.com/libzim/python-libzim)
 #
@@ -19,7 +32,7 @@
 
 import pathlib
 import datetime
-from collections import defaultdict
+import collections
 
 from .wrapper import Creator as _Creator
 from .wrapper import WritingBlob as Blob
@@ -28,113 +41,132 @@ __all__ = ["Article", "Blob", "Creator"]
 
 
 class Article:
+    """ Article stub to override
+
+        Pass a subclass of it to Creator.add_article() """
+
     def __init__(self):
         self._blob = None
 
-    def get_url(self):
+    def get_url(self) -> str:
+        """ Full URL of article including namespace """
         raise NotImplementedError
 
-    def get_title(self):
+    def get_title(self) -> str:
+        """ Article title. Might be indexed and used in suggestions """
         raise NotImplementedError
 
-    def is_redirect(self):
+    def is_redirect(self) -> bool:
+        """ Whether this redirects to another article (cf. redirec_url) """
         raise NotImplementedError
 
-    def get_mime_type(self):
+    def get_mime_type(self) -> str:
+        """ MIME-type of the article's content. A/ namespace reserved to text/html """
         raise NotImplementedError
 
-    def get_filename(self):
+    def get_filename(self) -> str:
+        """ Filename to get content from. Blank string "" if not used """
         raise NotImplementedError
 
-    def should_compress(self):
+    def should_compress(self) -> bool:
+        """ Whether the article's content should be compressed or not """
         raise NotImplementedError
 
-    def should_index(self):
+    def should_index(self) -> bool:
+        """ Whether the article's content should be indexed or not """
         raise NotImplementedError
 
-    def redirect_url(self):
+    def redirect_url(self) -> str:
+        """ Full URL including namespace of another article """
         raise NotImplementedError
 
-    def _get_data(self):
+    def _get_data(self) -> Blob:
+        """ Internal data-retrieval with a cache to the content's pointer
+
+            You don't need to override this """
         if self._blob is None:
             self._blob = self.get_data()
         return self._blob
 
-    def get_data(self):
+    def get_data(self) -> Blob:
+        """ Blob containing the complete content of the article """
         raise NotImplementedError
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"{self.__class__.__name__}(url={self.get_url()}, title={self.get_title()})"
 
 
 class MetadataArticle(Article):
-    def __init__(self, url, metadata_content):
+    """ Simple Article sub-class for key-value articles on M/ metadata namespace """
+
+    def __init__(self, url: str, metadata_content: str):
         Article.__init__(self)
         self.url = url
         self.metadata_content = metadata_content
 
-    def is_redirect(self):
+    def is_redirect(self) -> bool:
         return False
 
-    def get_url(self):
+    def get_url(self) -> str:
         return f"M/{self.url}"
 
-    def get_title(self):
+    def get_title(self) -> str:
         return ""
 
-    def get_mime_type(self):
+    def get_mime_type(self) -> str:
         return "text/plain"
 
-    def get_filename(self):
+    def get_filename(self) -> str:
         return ""
 
-    def should_compress(self):
+    def should_compress(self) -> bool:
         return True
 
-    def should_index(self):
+    def should_index(self) -> bool:
         return False
 
-    def get_data(self):
+    def get_data(self) -> Blob:
         return Blob(self.metadata_content)
 
 
-def pascalize(keyword):
-    """ Converts python case to pascal case. example: long_description-> LongDescription """
-    return "".join(keyword.title().split("_"))
-
-
 class Creator:
-    """
-    A class to represent a Zim Creator.
+    """ Zim Creator.
 
-    Attributes
-    ----------
-    *c_creator : zim.Creator
-        a pointer to the C++ Creator object
-    _finalized : bool
-        flag if the creator was finalized
-    _filename : pathlib.Path
-        Zim file path
-    _main_page : str
-        Zim file main page
-    _index_language : str
-        Zim file Index language
-    _min_chunk_size : str
-        Zim file minimum chunk size
-    _article_counter
-        Zim file article counter
-    _metadata
-        Zim file metadata
-    """
+        Attributes
+        ----------
+        *_creatorWrapper : wrapper.ZimCreatorWrapper
+            a pointer to the C++ Creator object wrapper
+        filename : pathlib.Path
+            Zim file path
+        main_page : str
+            Zim file main page (without namespace)
+        language : str
+            Zim file Index language
+        _article_counter
+            Zim file article counter
+        _metadata
+            Zim file metadata """
 
-    def __init__(self, filename, main_page, index_language="eng", min_chunk_size=2048):
+    def __init__(
+        self, filename: pathlib.Path, main_page: str, index_language: str = "eng", min_chunk_size: int = 2048,
+    ):
+        """ Creates a ZIM Creator
+
+            Parameters
+            ----------
+            filename : Path to create the ZIM file at
+            main_page: ZIM file main article URL (without namespace, must be in A/)
+            index_language: content language to inform indexer with (ISO-639-3)
+            min_chunk_size: minimum size of chunks for compression """
+
         self._creatorWrapper = _Creator(str(filename), main_page, index_language, min_chunk_size)
         self.filename = pathlib.Path(filename)
         self.main_page = main_page
         self.language = index_language
         self._metadata = {}
-        self._article_counter = defaultdict(int)
+        self._article_counter = collections.defaultdict(int)
         self.update_metadata(date=datetime.date.today(), language=index_language)
+        self._closed = False
 
     def __enter__(self):
         return self
@@ -143,38 +175,59 @@ class Creator:
         self.close()
 
     def __del__(self):
-        self.close()
+        if not self._closed:
+            self.close()
 
-    def add_article(self, article):
+    def add_article(self, article: Article):
+        """ Adds an article to the Creator.
+
+            Parameters
+            ----------
+            article : Zim writer Article
+                The article to add to the file
+            Raises
+            ------
+                RuntimeError
+                    If the ZimCreator was already finalized """
         self._creatorWrapper.add_article(article)
         if not article.is_redirect():
-            self._update_article_counter(article)
-
-    def _update_article_counter(self, article):
-        # default dict update
-        self._article_counter[article.get_mime_type().strip()] += 1
+            # update article counter
+            self._article_counter[article.get_mime_type().strip()] += 1
 
     def update_metadata(self, **kwargs: str):
         """ Updates Creator metadata for ZIM, supplied as keyword arguments """
-        new_metadata = {pascalize(k): v for k, v in kwargs.items()}
-        self._metadata.update(new_metadata)
 
-    def write_metadata(self):
+        def pascalize(keyword: str):
+            """ Converts python case to pascal case.
+
+                example: long_description -> LongDescription """
+            return "".join(keyword.title().split("_"))
+
+        self._metadata.update({pascalize(k): v for k, v in kwargs.items()})
+
+    def close(self):
+        """ Finalizes and writes added articles to the file
+
+            Raises
+            ------
+                RuntimeError
+                    If the ZimCreator was already finalized """
+        if self._closed:
+            raise RuntimeError("Creator already closed")
+
+        # Store _medtadata dict as MetadataArticle
         for key, value in self._metadata.items():
-            if key == "Date" and isinstance(value, datetime.date):
+            if key == "Date" and isinstance(value, (datetime.date, datetime.datetime)):
                 value = value.strftime("%Y-%m-%d")
             article = MetadataArticle(key, value)
             self._creatorWrapper.add_article(article)
 
-        article = MetadataArticle("Counter", self._get_counter_string())
+        counter_str = ";".join([f"{k}={v}" for (k, v) in self._article_counter.items()])
+        article = MetadataArticle("Counter", counter_str)
         self._creatorWrapper.add_article(article)
 
-    def _get_counter_string(self):
-        return ";".join(["%s=%s" % (k, v) for (k, v) in self._article_counter.items()])
-
-    def close(self):
-        self.write_metadata()
         self._creatorWrapper.finalize()
+        self._closed = True
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f"Creator(filename={self.filename})"

--- a/tests/test_libzim.py
+++ b/tests/test_libzim.py
@@ -128,21 +128,6 @@ def test_article_metadata(tmpdir, metadata):
         assert zim_creator._metadata == metadata
 
 
-def test_check_mandatory_metadata(tmpdir):
-    with Creator(
-        str(tmpdir / "test.zim"), main_page="welcome", index_language="eng", min_chunk_size=2048,
-    ) as zim_creator:
-        assert not zim_creator.mandatory_metadata_ok()
-        zim_creator.update_metadata(
-            creator="python-libzim",
-            description="Created in python",
-            name="Hola",
-            publisher="Monadical",
-            title="Test Zim",
-        )
-        assert zim_creator.mandatory_metadata_ok()
-
-
 def test_creator_params(tmpdir):
     path = str(tmpdir / "test.zim")
     main_page = "welcome"

--- a/tests/test_libzim.py
+++ b/tests/test_libzim.py
@@ -184,3 +184,11 @@ def test_double_close(tmpdir):
     creator.close()
     with pytest.raises(RuntimeError):
         creator.close()
+
+
+def test_default_creator_params(tmpdir):
+    """ ensure we can init a Creator without specifying all params """
+    creator = Creator(str(tmpdir / "test.zim"), "welcome")
+    assert True  # we could init the Creator without specifying other params
+    assert creator.language == "eng"
+    assert creator.main_page == "welcome"

--- a/tests/test_libzim_file_reader.py
+++ b/tests/test_libzim_file_reader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from libzim.reader import File
+from libzim.reader import File, NotFound
 
 DATA_DIR = Path(__file__).parent
 
@@ -110,9 +110,9 @@ def test_search(reader):
 
 
 def test_get_wrong_article(reader):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError):  # out of range
         reader.get_article_by_id(reader.article_count + 100)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(NotFound):
         reader.get_article("A/I_do_not_exists")
 
 

--- a/tests/test_libzim_file_reader.py
+++ b/tests/test_libzim_file_reader.py
@@ -10,7 +10,7 @@ DATA_DIR = Path(__file__).parent
 
 ZIMFILES = [
     {
-        "filename": str(DATA_DIR / "wikipedia_es_physics_mini.zim"),
+        "filename": DATA_DIR / "wikipedia_es_physics_mini.zim",
         "checksum": "99ea7a5598c6040c4f50b8ac0653b703",
         "namespaces": "-AIMX",
         "article_count": 22027,
@@ -43,6 +43,7 @@ def article_data():
 def test_zim_filename(reader, zimdata):
     for k, v in zimdata.items():
         assert getattr(reader, k) == v
+    assert isinstance(reader.filename, Path)
 
 
 def test_zim_read(reader, article_data):


### PR DESCRIPTION
Here's a collection of individual small fixes for identified issues:

*  Fixed #29: using default values on Creator init 
* Fixed #37: fixed `__repr__` for ReadArticle and File, added on Article
* Fixed #38: raising NotFound on unavailable article.
this might not be wanted as per discussion on #38 and matthieu's suggestion to leave that to new libzim's. I believe this might be forward compatible but we can strip this out if we think it won't.
* Issue #38: added has_article(url) to test an URL.
Currently uses the `NotFound` exception but could be changed to use `RuntimeError` should we opt NotFound out.
* Fixed #30: get_metadata() now returns a dict of metadata
Didn't receive comment on that issue so I impl. what made sense to me.
* Fixed #45: Creator now accepts pathlib for filename
* 1e65ca5 simplifies the public Creator API by refactoring what's used only once and by using better docstrings and annotations. **warning**: added a `._closed` prop to avoid the double-close issue we'd get on exiting the contextmanager and (auto) deletion.

Please look at them individually and let me know which would make sense to push as separate PRs.