### PR TITLE
rename get_namespaces_count with get_namespace_count

### DIFF
--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -471,7 +471,7 @@ cdef class FilePy:
             A string containing initials of all namespaces in the file (ex: "-AIMX") """
         return self.c_file.getNamespaces().decode("UTF-8", "strict")
 
-    def get_namespaces_count(self, str ns) -> int:
+    def get_namespace_count(self, str ns) -> int:
         """ Articles count within a namespace -> int
 
             Returns

--- a/tests/test_libzim_file_reader.py
+++ b/tests/test_libzim_file_reader.py
@@ -96,7 +96,7 @@ def test_get_article_by_id(reader, article_data):
 
 def test_namespace_count(reader):
     namespaces = reader.namespaces
-    num_articles = sum(reader.get_namespaces_count(ns) for ns in namespaces)
+    num_articles = sum(reader.get_namespace_count(ns) for ns in namespaces)
     assert reader.article_count == num_articles
 
 


### PR DESCRIPTION
As this method returns the count for a single namespace, its name should be singular