### PR TITLE
Upgrade cython to latest stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
 env:
   LIBZIM_VERSION: 6.1.6
   LIBZIM_INCLUDE_PATH: include/zim
-  CYTHON_VERSION: 0.29.6
   TWINE_USERNAME: __token__
   TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
   # TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
@@ -78,7 +77,7 @@ jobs:
 
       - name: Build cython, sdist, and bdist_wheels
         run: |
-          pip install --upgrade cython==$CYTHON_VERSION setuptools pip wheel
+          pip install --upgrade "cython>=0.29.20,<3.0" setuptools pip wheel
           python3 setup.py build_ext --rpath='$ORIGIN'
           if [[  "${{ matrix.python-version }}" == "3.6" ]]
           then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on: [push]
 env:
   LIBZIM_VERSION: 6.1.6
   LIBZIM_INCLUDE_PATH: include/zim
-  CYTHON_VERSION: 0.29.6
   MAX_LINE_LENGTH: 110
 
 jobs:
@@ -98,7 +97,7 @@ jobs:
 
       - name: Build cython, sdist, and bdist_wheel
         run: |
-          pip install --upgrade cython==$CYTHON_VERSION setuptools pip wheel
+          pip install --upgrade pip install "cython>=0.29.20,<3.0" setuptools pip wheel
           python3 setup.py build_ext
           python3 setup.py sdist bdist_wheel
 


### PR DESCRIPTION
Cython is a fast evolving project with frequent fixes and improvements.
Keeping up-to-date on stable version makes sense as a failure to build
with a newer Cython would indicate a problem on our codebase.

@afreydev, what was the reason for using such an old version? `0.29.6` is dated Feb 27, 2019.