### PR TITLE
Use IndexError and KeyError on reader's get_article methods

### DIFF
--- a/libzim/reader.py
+++ b/libzim/reader.py
@@ -2,7 +2,6 @@
 
     - File to open and read ZIM files
     - Article are returned by File on get_article() and get_article_by_id()
-    - NotFound is raised on incorrect article URL query
 
     Usage:
 
@@ -12,5 +11,5 @@
     """
 
 # flake8: noqa
-from .wrapper import FilePy as File, NotFound
+from .wrapper import FilePy as File
 from .wrapper import ReadArticle as Article

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -34,9 +34,6 @@ import pathlib
 import datetime
 
 
-class NotFound(RuntimeError):
-    pass
-
 #########################
 #         Blob          #
 #########################
@@ -371,12 +368,12 @@ cdef class FilePy:
                 The ReadArticle object
             Raises
             ------
-                NotFound
+                KeyError
                     If an article with the provided long url is not found in the file """
         # Read to a zim::Article
         cdef wrapper.Article art = self.c_file.getArticleByUrl(url.encode('UTF-8'))
         if not art.good():
-            raise NotFound("Article not found for url")
+            raise KeyError("Article not found for url")
 
         article = ReadArticle.from_read_article(art)
         return article
@@ -408,14 +405,18 @@ cdef class FilePy:
         Raises
         ------
             RuntimeError
-                If there is a problem in retrieving article (id out of bound)
-            NotFound
-                If an article with the provided id is not found in the file """
+                If there is a problem in retrieving article
+            IndexError
+                If an article with the provided id is not found (id out of bound) """
 
         # Read to a zim::Article
-        cdef wrapper.Article art = self.c_file.getArticle(<int> article_id)
+        cdef wrapper.Article art
+        try:
+            art = self.c_file.getArticle(<int> article_id)
+        except RuntimeError as exc:
+            raise(IndexError(exc))
         if not art.good():
-            raise NotFound("Article not found for id")
+            raise IndexError("Article not found for id")
 
         article = ReadArticle.from_read_article(art)
         return article

--- a/tests/test_libzim_file_reader.py
+++ b/tests/test_libzim_file_reader.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from libzim.reader import File, NotFound
+from libzim.reader import File
 
 DATA_DIR = Path(__file__).parent
 
@@ -111,9 +111,9 @@ def test_search(reader):
 
 
 def test_get_wrong_article(reader):
-    with pytest.raises(RuntimeError):  # out of range
+    with pytest.raises(IndexError):  # out of range
         reader.get_article_by_id(reader.article_count + 100)
-    with pytest.raises(NotFound):
+    with pytest.raises(KeyError):
         reader.get_article("A/I_do_not_exists")
 
 


### PR DESCRIPTION
As C++ throws `RuntimeError` on incorrect URL or id when retrieving article, it is not the most practical nor pertinent choice.
We then introduced NotFound on some of those queries.
Raising `KeyError` on incorrect URL and `IndexError` on incorrect id makes more sense
and have the benefit of being standard exceptions.