### PR TITLE
Forward exceptions from Article's virtual methods

### DIFF
--- a/libzim/lib.cxx
+++ b/libzim/lib.cxx
@@ -65,8 +65,10 @@ std::string ZimArticleWrapper::callCythonReturnString(std::string methodName) co
     int error;
 
     std::string ret_val = string_cy_call_fct(this->m_obj, methodName, &error);
-    if (error)
+    if (error && error == 1)
         throw std::runtime_error("The pure virtual function " + methodName + " must be override");
+    if (error)
+        throw std::runtime_error("The virtual function " + methodName + " threw an exception");
 
     return ret_val;
 }
@@ -79,8 +81,10 @@ zim::Blob ZimArticleWrapper::callCythonReturnBlob(std::string methodName) const
     int error;
 
     zim::Blob ret_val = blob_cy_call_fct(this->m_obj, methodName, &error);
-    if (error)
+    if (error && error == 1)
         throw std::runtime_error("The pure virtual function " + methodName + " must be override");
+    if (error)
+        throw std::runtime_error("The virtual function " + methodName + " threw an exception");
 
     return ret_val;
 }
@@ -93,8 +97,10 @@ bool ZimArticleWrapper::callCythonReturnBool(std::string methodName) const
     int error;
 
     bool ret_val = bool_cy_call_fct(this->m_obj, methodName, &error);
-    if (error)
+    if (error && error == 1)
         throw std::runtime_error("The pure virtual function " + methodName + " must be override");
+    if (error)
+        throw std::runtime_error("The virtual function " + methodName + " threw an exception");
 
     return ret_val;
 }
@@ -107,8 +113,10 @@ uint64_t ZimArticleWrapper::callCythonReturnInt(std::string methodName) const
     int error;
 
     int ret_val = int_cy_call_fct(this->m_obj, methodName, &error);
-    if (error)
+    if (error && error == 1)
         throw std::runtime_error("The pure virtual function " + methodName + " must be override");
+    if (error)
+        throw std::runtime_error("The virtual function " + methodName + " threw an exception");
 
     return ret_val;
 }

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -119,7 +119,11 @@ cdef public api:
     string string_cy_call_fct(object obj, string method, int *error) with gil:
         """Lookup and execute a pure virtual method on ZimArticle returning a string"""
         func = get_article_method_from_object(obj, method, error)
-        ret_str = func()
+        try:
+            ret_str = func()
+        except Exception:
+            error[0] = 2
+            raise
         return ret_str.encode('UTF-8')
 
     wrapper.Blob blob_cy_call_fct(object obj, string method, int *error) with gil:
@@ -127,18 +131,30 @@ cdef public api:
         cdef WritingBlob blob
 
         func = get_article_method_from_object(obj, method, error)
-        blob = func()
+        try:
+            blob = func()
+        except Exception:
+            error[0] = 2
+            raise
         return dereference(blob.c_blob)
 
     bool bool_cy_call_fct(object obj, string method, int *error) with gil:
         """Lookup and execute a pure virtual method on ZimArticle returning a bool"""
         func = get_article_method_from_object(obj, method, error)
-        return func()
+        try:
+            return func()
+        except Exception:
+            error[0] = 2
+            raise
 
     uint64_t int_cy_call_fct(object obj, string method, int *error) with gil:
         """Lookup and execute a pure virtual method on ZimArticle returning an int"""
         func = get_article_method_from_object(obj, method, error)
-        return <uint64_t> func()
+        try:
+            return <uint64_t> func()
+        except Exception:
+            error[0] = 2
+            raise
 
 cdef class Creator:
     """ Zim Creator


### PR DESCRIPTION
This addresses (badly I presume) the problem that users need to stop on user-code error inside `Article`'s virtual method.
It's essential otherwise they'll endup with garbaged ZIM files.
This first commit (8ed926d) achieves that but there is probably a be a better way to do it.

--

Another related commit regards the *next step* in this process, being able to stop the creation process when an error occurs.
The only workaround I found was to prevent calling `finalize()` (node-libzim and zimwritefs exits before calling it for instance).
As we call `close()` and thus `finalize()` on `__exit__` and `__del__`, for convenience, we have to bypass this.

It works fine in scrapers but not on the tests as the reader's tests trigger a manual garbage collection which the libzim is not happy with, as `finalize()` was never called…

To overcome that yet still test this important *capability*, I'm instanciating a new VM in the test.

@mgautierfr, please consider it a POC to start the discussion on this. We can surely opt this test out for now . Exception stuff is mandatory though.