### PR TITLE
fixed redirect_url accessor

### DIFF
--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -76,9 +76,9 @@ class Article:
         """ Whether the article's content should be indexed or not """
         raise NotImplementedError("should_index must be implemented.")
 
-    def redirect_url(self) -> str:
+    def get_redirect_url(self) -> str:
         """ Full URL including namespace of another article """
-        raise NotImplementedError("redirect_url must be implemented.")
+        raise NotImplementedError("get_redirect_url must be implemented.")
 
     def _get_data(self) -> Blob:
         """ Internal data-retrieval with a cache to the content's pointer

--- a/tests/test_libzim.py
+++ b/tests/test_libzim.py
@@ -253,3 +253,24 @@ except Exception:
     py = subprocess.run([sys.executable, "-c", pycode])
     assert py.returncode == 0
     assert not path.exists()
+
+
+def test_redirect_url(tmpdir):
+    url = "A/welcome"
+    redirect_url = "A/home"
+
+    class RedirectArticle(SimpleArticle):
+        def is_redirect(self):
+            return True
+
+        def get_redirect_url(self):
+            return url
+
+    path = tmpdir / "test.zim"
+    with Creator(path, "welcome") as zim_creator:
+        zim_creator.add_article(SimpleArticle(title="Hello", mime_type="text/html", content="", url=url))
+        zim_creator.add_article(RedirectArticle(content="", title="", mime_type="", url=redirect_url))
+
+    with File(path) as reader:
+        assert reader.get_article(redirect_url).is_redirect
+        assert reader.get_article(redirect_url).get_redirect_article().longurl == url


### PR DESCRIPTION
`lib.cxx` mirrors libzim's `getRedirectUrl()` with `get_redirect_url()`.
That methods had incorrectly been named `redirect_url`.

https://github.com/openzim/python-libzim/blob/3092492769af58894f0dab051748c54748f0c827/libzim/lib.cxx#L158-L164