### PR TITLE
Rewrite runtime path lookup to libzim on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           echo ::set-env name=LIBZIM_RELEASE::libzim_macos-x86_64-$LIBZIM_VERSION
           echo ::set-env name=LIBZIM_LIBRARY_PATH::lib/libzim.${LIBZIM_VERSION:0:1}.dylib
           echo ::set-env name=PLAFTORM_NAME::macosx_10.9_x86_64
+          echo ::set-env name=RPATH::@loader_path/
 
       - name: set linux environ
         if: matrix.os == 'ubuntu-latest'
@@ -46,6 +47,7 @@ jobs:
           echo ::set-env name=LIBZIM_RELEASE::libzim_linux-x86_64-$LIBZIM_VERSION
           echo ::set-env name=LIBZIM_LIBRARY_PATH::lib/x86_64-linux-gnu/libzim.so.$LIBZIM_VERSION
           echo ::set-env name=PLAFTORM_NAME::manylinux1_x86_64
+          echo ::set-env name=RPATH::\$ORIGIN
 
       - name: Cache libzim dylib & headers
         uses: actions/cache@master
@@ -78,7 +80,7 @@ jobs:
       - name: Build cython, sdist, and bdist_wheels
         run: |
           pip install --upgrade "cython>=0.29.20,<3.0" setuptools pip wheel
-          python3 setup.py build_ext --rpath='$ORIGIN'
+          python3 setup.py build_ext --rpath $RPATH
           if [[  "${{ matrix.python-version }}" == "3.6" ]]
           then
             python3 setup.py sdist
@@ -86,7 +88,9 @@ jobs:
 
       - name: add macOS libzim binary to source for wheel
         if: matrix.os == 'macos-latest'
-        run: cp -p lib/libzim.${LIBZIM_VERSION:0:1}.dylib libzim
+        run: |
+          install_name_tool -change libzim.6.dylib @loader_path/libzim.6.dylib $(find build -name "wrapper*.so")
+          cp -p lib/libzim.${LIBZIM_VERSION:0:1}.dylib libzim
 
       - name: add Linux libzim binary to source for wheel
         if: matrix.os == 'ubuntu-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3.post0
+
+* fixed access to bundled libzim on macOS (missing rpath)
+
 ## 0.0.3
 
 * [reader] fixed `main_page` retrieval

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ wrapper_extension = Extension(
 setup(
 # Basic information about libzim module
     name="libzim",
-    version="0.0.3",
+    version="0.0.3.post0",
     url=GITHUB_URL,
     project_urls={
         'Source': GITHUB_URL,


### PR DESCRIPTION
Using the 0.0.3 release, I realized we have a packaging problem on macOS:
the wrapper is looking for the libzim in standard location, which is good for those who have the libzim installed but not the expected behavior (that's why we bundle it!)

So this PR fixes that by telling the wrapper to look for the libzim next to it.
The `$ORIGIN` rpath was already set for linux but macOS behaves differently (equivalent is `@loader_path/`)

Changes:
* Change `--rpath` argument based on platform
* Fix `--rpath` behavior on macOS [python#36353](https://bugs.python.org/issue36353)
* Manually set the rpath on macOS (fix above sends proper command but output lib doesn't include it anyway)
* Changed version to `0.0.3.post0` so we can publish on PyPi

This has been tested on macOS and Linux via [test.pypi.org](https://test.pypi.org/project/libzim/0.0.3.post1/)