### PR TITLE
Include tests/*.zim files in the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include README.md
 include tests/*.py
+include tests/*.zim
 include pyproject.toml
 
 recursive-include libzim *


### PR DESCRIPTION
This will allow tests to pass from people/distributions (e.g. Debian) using
the release tarball.

Fixes #68.