### PR TITLE
Ability to choose compression algoritm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.0.4
 
+* added compression argument to Creator to set compression algorithm (libzim.writer.Compression)
+* Creator positional arguments order changed: min_chunk_size moved after compression
 * using libzim 6.1.8
 
 ## 0.0.3.post0

--- a/libzim/lib.cxx
+++ b/libzim/lib.cxx
@@ -204,8 +204,8 @@ std::string ZimArticleWrapper::getNextCategory()
 class OverriddenZimCreator : public zim::writer::Creator
 {
 public:
-    OverriddenZimCreator(std::string mainPage)
-        : zim::writer::Creator(true),
+    OverriddenZimCreator(std::string mainPage, zim::CompressionType compression)
+        : zim::writer::Creator(true, compression),
           mainPage(mainPage) {}
 
     virtual zim::writer::Url getMainUrl() const
@@ -232,12 +232,12 @@ ZimCreatorWrapper::~ZimCreatorWrapper()
 
 ZimCreatorWrapper *
 ZimCreatorWrapper::
-    create(std::string fileName, std::string mainPage, std::string fullTextIndexLanguage, int minChunkSize)
+    create(std::string fileName, std::string mainPage, std::string fullTextIndexLanguage, zim::CompressionType compression, int minChunkSize)
 
 {
     bool shouldIndex = !fullTextIndexLanguage.empty();
 
-    OverriddenZimCreator *c = new OverriddenZimCreator(mainPage);
+    OverriddenZimCreator *c = new OverriddenZimCreator(mainPage, compression);
     c->setIndexing(shouldIndex, fullTextIndexLanguage);
     c->setMinChunkSize(minChunkSize);
     c->startZimCreation(fileName);

--- a/libzim/lib.h
+++ b/libzim/lib.h
@@ -70,7 +70,7 @@ public:
     OverriddenZimCreator *_creator;
     ZimCreatorWrapper(OverriddenZimCreator *creator);
     ~ZimCreatorWrapper();
-    static ZimCreatorWrapper *create(std::string fileName, std::string mainPage, std::string fullTextIndexLanguage, int minChunkSize);
+    static ZimCreatorWrapper *create(std::string fileName, std::string mainPage, std::string fullTextIndexLanguage, zim::CompressionType compression, int minChunkSize);
     void addArticle(std::shared_ptr<ZimArticleWrapper> article);
     void finalize();
     void setMainUrl(std::string newUrl);

--- a/libzim/wrapper.pxd
+++ b/libzim/wrapper.pxd
@@ -29,6 +29,13 @@ from libcpp.vector cimport vector
 cdef extern from "zim/zim.h" namespace "zim":
     ctypedef uint64_t size_type
     ctypedef uint64_t offset_type
+    ctypedef enum CompressionType:
+        zimcompDefault
+        zimcompNone
+        zimcompZip
+        zimcompBzip2
+        zimcompLzma
+        zimcompZstd
 
 
 cdef extern from "zim/blob.h" namespace "zim":
@@ -65,7 +72,7 @@ cdef extern from "lib.h":
 
     cdef cppclass ZimCreatorWrapper:
         @staticmethod
-        ZimCreatorWrapper *create(string fileName, string mainPage, string fullTextIndexLanguage, int minChunkSize) nogil except +
+        ZimCreatorWrapper *create(string fileName, string mainPage, string fullTextIndexLanguage, CompressionType compression, int minChunkSize) nogil except +
         void addArticle(shared_ptr[ZimArticleWrapper] article) nogil except +
         void finalize() nogil except +
         Url getMainUrl() except +
@@ -137,5 +144,5 @@ cdef extern from "zim/file.h" namespace "zim":
         string getChecksum() except +
         string getFilename() except +
 
-        unique_ptr[Search] search(const string query, int start, int end); 
+        unique_ptr[Search] search(const string query, int start, int end);
         unique_ptr[Search] suggestions(const string query, int start, int end);

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -20,6 +20,7 @@
 
 cimport libzim.wrapper as wrapper
 
+import enum
 from typing import Generator
 from cython.operator import dereference, preincrement
 from cpython.ref cimport PyObject
@@ -146,6 +147,15 @@ cdef public api:
 
         return 0
 
+
+class Compression(enum.Enum):
+    """ Compression algorithms available to create ZIM files """
+    none = wrapper.CompressionType.zimcompNone
+    zip = wrapper.CompressionType.zimcompZip
+    lzma = wrapper.CompressionType.zimcompLzma
+    zstd = wrapper.CompressionType.zimcompZstd
+
+
 cdef class Creator:
     """ Zim Creator
 
@@ -159,7 +169,7 @@ cdef class Creator:
     cdef wrapper.ZimCreatorWrapper *c_creator
     cdef bool _finalized
 
-    def __cinit__(self, str filename: str, str main_page: str = "", str index_language: str = "eng", min_chunk_size: int = 2048):
+    def __cinit__(self, str filename: str, str main_page: str = "", str index_language: str = "eng", compression = Compression.lzma, int min_chunk_size = 2048):
         """ Constructs a Zim Creator from parameters.
 
             Parameters
@@ -170,10 +180,11 @@ cdef class Creator:
                 Zim file main page (without namespace, must be in A/)
             index_language : str
                 Zim file index language (default eng)
+            compression: Compression
+                Compression algorithm to use
             min_chunk_size : int
                 Minimum chunk size (default 2048) """
-
-        self.c_creator = wrapper.ZimCreatorWrapper.create(filename.encode("UTF-8"), main_page.encode("UTF-8"), index_language.encode("UTF-8"), min_chunk_size)
+        self.c_creator = wrapper.ZimCreatorWrapper.create(filename.encode("UTF-8"), main_page.encode("UTF-8"), index_language.encode("UTF-8"), compression.value, min_chunk_size)
         self._finalized = False
 
     def __dealloc__(self):

--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -33,8 +33,9 @@
 import pathlib
 import datetime
 import collections
+from typing import Union
 
-from .wrapper import Creator as _Creator
+from .wrapper import Creator as _Creator, Compression
 from .wrapper import WritingBlob as Blob
 
 __all__ = ["Article", "Blob", "Creator"]
@@ -148,7 +149,12 @@ class Creator:
             Zim file metadata """
 
     def __init__(
-        self, filename: pathlib.Path, main_page: str, index_language: str = "eng", min_chunk_size: int = 2048,
+        self,
+        filename: pathlib.Path,
+        main_page: str,
+        index_language: str = "eng",
+        compression: Union[Compression, str] = Compression.lzma,
+        min_chunk_size: int = 2048,
     ):
         """ Creates a ZIM Creator
 
@@ -157,9 +163,12 @@ class Creator:
             filename : Path to create the ZIM file at
             main_page: ZIM file main article URL (without namespace, must be in A/)
             index_language: content language to inform indexer with (ISO-639-3)
-            min_chunk_size: minimum size of chunks for compression """
+            min_chunk_size: minimum size of chunks for compression
+            compression: compression algorithm to use """
+        if not isinstance(compression, Compression):
+            compression = getattr(Compression, compression.lower())
 
-        self._creatorWrapper = _Creator(str(filename), main_page, index_language, min_chunk_size)
+        self._creatorWrapper = _Creator(str(filename), main_page, index_language, compression, min_chunk_size)
         self.filename = pathlib.Path(filename)
         self.main_page = main_page
         self.language = index_language


### PR DESCRIPTION
libzim 6.1.8 added the ability to choose the compression type on creation.
This adds support for it in the Creator and other required parts.

On user API, the main change is a `compression` argument to the Creator.
This can receive either a string (`default`, `none`, `zip`, `lzma`, `zstd`) or a member
of the new `Compression` enum (members named after strings above)

This enum converts to `zim::CompressionType` and that is forwarded down to the libzim.

## Breaking change

I chose to add the new `compression` argument to the Creator before the `min_chunk_size` as it seems there might better chances people would customize it than the chunks size.
I might be wrong or it might just not be wanted. Let me know and I'd change that. Because of this change, two tests using positional arguments were changed.

--

**Note**: this assumes https://github.com/openzim/libzim/issues/371 is fixed.