### PR TITLE
tests: Skip if necessary ZIM file isn't present

### DIFF
--- a/tests/test_libzim_file_reader.py
+++ b/tests/test_libzim_file_reader.py
@@ -26,6 +26,8 @@ def zimdata(request):
 
 @pytest.fixture
 def reader(zimdata):
+    if not zimdata["filename"].exists():
+        pytest.skip(f"{zimdata['filename']} doesn't exist")
     return File(zimdata["filename"])
 
 


### PR DESCRIPTION
The large ZIM files used for tests are not included in the release
tarball because of their size. But we still want the tests to pass
in that case, so skip if the file is missing.

Fixes #68.

This is an alternative to #69.