### PR TITLE
Require get_size() implementation by user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Creator positional arguments order changed: min_chunk_size moved after compression
 * Reader `get_suggestions_results_count` renamed `get_estimated_suggestions_results_count` (#71)
 * Reader `get_search_results_count` renamed `get_estimated_search_results_count` (#71)
+* Article subclasses must implement `get_size()`
+* Fixed using `get_filename()` (#71)
 * using libzim 6.1.8
 
 ## 0.0.3.post0

--- a/libzim/lib.cxx
+++ b/libzim/lib.cxx
@@ -177,7 +177,7 @@ ZimArticleWrapper::getData() const
 zim::size_type
 ZimArticleWrapper::getSize() const
 {
-    return this->getData().size();
+    return callCythonReturnInt("get_size");
 }
 
 bool ZimArticleWrapper::isLinktarget() const

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -51,6 +51,9 @@ cdef class WritingBlob:
             self.ref_content = content
         self.c_blob = new wrapper.Blob(<char *> self.ref_content, len(self.ref_content))
 
+    def size(self):
+        return self.c_blob.size()
+
     def __dealloc__(self):
         if self.c_blob != NULL:
             del self.c_blob

--- a/libzim/writer.py
+++ b/libzim/writer.py
@@ -93,6 +93,10 @@ class Article:
         """ Blob containing the complete content of the article """
         raise NotImplementedError("get_data must be implemented.")
 
+    def get_size(self) -> int:
+        """ Size of get_data's result in bytes """
+        raise NotImplementedError("get_size must be implemented.")
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(url={self.get_url()}, title={self.get_title()})"
 
@@ -128,6 +132,9 @@ class MetadataArticle(Article):
 
     def get_data(self) -> Blob:
         return Blob(self.metadata_content)
+
+    def get_size(self) -> int:
+        return self.get_data().size()
 
 
 class Creator:


### PR DESCRIPTION
`getSize` being implemented in the wrapper, and its implementation relying on returning
the size of get_data(), it prevented the use of get_filename (allowed by libzim).

This now requires user to implement `get_size()`, not making any assumption about it.

- API break: `get_size()` now mandatory on Article
- WritingBlob now exposes a `size()` that returns the C Blob's size so we can still fetch
the size from `get_data()`
- tests checking for implementation of mandatory methods adapted so get_size returns a positive
size when testing get_data (otherwise it's skipped)
- Added a test for `get_filename()` usage