### PR TITLE
Renamed search/suggestions count methods to imply estimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * added compression argument to Creator to set compression algorithm (libzim.writer.Compression)
 * Creator positional arguments order changed: min_chunk_size moved after compression
+* Reader `get_suggestions_results_count` renamed `get_estimated_suggestions_results_count` (#71)
+* Reader `get_search_results_count` renamed `get_estimated_search_results_count` (#71)
 * using libzim 6.1.8
 
 ## 0.0.3.post0

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -546,8 +546,8 @@ cdef class FilePy:
             yield it.get_url().decode('UTF-8')
             preincrement(it)
 
-    def get_search_results_count(self, query: str) -> int:
-        """ Number of search results for a query -> int
+    def get_estimated_search_results_count(self, query: str) -> int:
+        """ Estimated number of search results for a query -> int
 
             Parameters
             ----------
@@ -556,12 +556,12 @@ cdef class FilePy:
             Returns
             -------
             int
-                Number of search results """
+                Estimated number of search results """
         cdef unique_ptr[wrapper.Search] search = self.c_file.search(query.encode('UTF-8'),0, 1)
         return dereference(search).get_matches_estimated()
 
-    def get_suggestions_results_count(self, query: str) -> int:
-        """ Number of suggestions for a query -> int
+    def get_estimated_suggestions_results_count(self, query: str) -> int:
+        """ Estimated number of suggestions for a query -> int
 
             Parameters
             ----------
@@ -570,7 +570,7 @@ cdef class FilePy:
             Returns
             -------
             int
-                Number of article suggestions """
+                Estimated number of article suggestions """
         cdef unique_ptr[wrapper.Search] search = self.c_file.suggestions(query.encode('UTF-8'),0 , 1)
         return dereference(search).get_matches_estimated()
 


### PR DESCRIPTION
Methods `get_*_results_count` returns an estimated number of results (from the libzim).
It is important that the method names doesn't mislead users into thinking it's a definitive count.

This thus renames both methods and updates docstrings