### PR TITLE
Using the `release` environ for release GHA.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   release:
+    environment: release
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
I've created a `release` Environment in the repo and moved the secrets to the Environment.

Using this commit means that our *release* job in our release.yml workflow will only run if it has been approved by a member of the (newly created) @openzim/credentials Team (@kelson42 @mgautierfr @rgaudin as of now).

This looks like a good strategy to prevent leaking our secrets. I suggest we test it here and we'll see how duplicable that is: it's manually set to the job so it might require some refactoring for kiwix-build workflow to only have it on releases and not nightlies for instance.