### PR TITLE
Fixed suggestion count estimation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [push]
 
 env:
-  LIBZIM_VERSION: 2021-01-27
+  LIBZIM_VERSION: 2021-03-16
   LIBZIM_INCLUDE_PATH: include/zim
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   MAX_LINE_LENGTH: 88
@@ -57,14 +57,14 @@ jobs:
         run: |
           echo LIBZIM_EXT=dylib >> $GITHUB_ENV
           echo LIBZIM_RELEASE=libzim_macos-x86_64-$LIBZIM_VERSION >> $GITHUB_ENV
-          echo LIBZIM_LIBRARY_PATH=lib/libzim.6.dylib >> $GITHUB_ENV
+          echo LIBZIM_LIBRARY_PATH=lib/libzim.7.dylib >> $GITHUB_ENV
 
       - name: set linux environ
         if: matrix.os == 'ubuntu-latest'
         run: |
           echo LIBZIM_EXT=so >> $GITHUB_ENV
           echo LIBZIM_RELEASE=libzim_linux-x86_64-$LIBZIM_VERSION >> $GITHUB_ENV
-          echo LIBZIM_LIBRARY_PATH=lib/x86_64-linux-gnu/libzim.so.6.3.0 >> $GITHUB_ENV
+          echo LIBZIM_LIBRARY_PATH=lib/x86_64-linux-gnu/libzim.so.7.0.0 >> $GITHUB_ENV
 
       - name: Cache libzim dylib & headers
         uses: actions/cache@master

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -670,7 +670,7 @@ cdef class PyArchive:
         cdef wrapper.ZimSearch search = wrapper.ZimSearch(dereference(self.c_archive))
         search.set_suggestion_mode(False)
         search.set_query(query.encode('UTF-8'))
-        search.set_range(0, 1)
+        search.set_range(0, self.entry_count)
 
         return search.get_matches_estimated()
 
@@ -688,7 +688,7 @@ cdef class PyArchive:
         cdef wrapper.ZimSearch search = wrapper.ZimSearch(dereference(self.c_archive))
         search.set_suggestion_mode(True)
         search.set_query(query.encode('UTF-8'))
-        search.set_range(0, 1)
+        search.set_range(0, self.entry_count)
 
         return search.get_matches_estimated()
 

--- a/tests/test_libzim_creator.py
+++ b/tests/test_libzim_creator.py
@@ -173,7 +173,7 @@ def test_creator_verbose(fpath, verbose):
     lines = output.splitlines()
     if verbose:
         assert "T:" in output
-        assert len(lines) >= 20
+        assert len(lines) >= 5
     else:
         assert len(lines) == 2
 

--- a/tests/test_libzim_reader.py
+++ b/tests/test_libzim_reader.py
@@ -16,7 +16,7 @@ from libzim.reader import Archive
 ZIMS_DATA = {
     "blank.zim": {
         "filename": "blank.zim",
-        "filesize": 25675,
+        "filesize": 25789,
         "new_ns": True,
         "mutlipart": False,
         "zim_uuid": None,
@@ -75,7 +75,7 @@ ZIMS_DATA = {
         "is_valid": True,
         "entry_count": 371,
         "suggestion_string": "lucky",
-        "suggestion_count": 2,  # includes redirect?
+        "suggestion_count": 1,
         "suggestion_result": ["A/That_Lucky_Old_Sun"],
         "search_string": "lucky",
         "search_count": 1,
@@ -116,7 +116,7 @@ ZIMS_DATA = {
         "entry_count": 54,
         "suggestion_string": "Nayriri",
         "suggestion_count": 2,
-        "suggestion_result": ["A/index", "A/Nayriri_Uñstawi"],
+        "suggestion_result": ["A/Nayriri_Uñstawi", "A/index"],
         "search_string": "Nayriri",
         "search_count": 1,
         "search_result": ["A/Nayriri_Uñstawi"],


### PR DESCRIPTION
Following discussion at openzim/libzim#521, it appears
pylibzim is returning an invalid estimated number of suggestions while libzim is correct
Adjusted the search object's range to match what is done in libzim.

Also updated the libzim version with test against to latest nightly as it includes related changes. Thus had to update the filesize of the blank zim file we create in tests.