### PR TITLE
Change get_url() to get_path() for libzim compatibility

### DIFF
--- a/libzim/wrapper.pxd
+++ b/libzim/wrapper.pxd
@@ -113,7 +113,7 @@ cdef extern from "zim/search_iterator.h" namespace "zim":
         search_iterator operator++()
         bint operator==(search_iterator)
         bint operator!=(search_iterator)
-        string get_url()
+        string get_path()
         string get_title()
 
 

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -627,7 +627,7 @@ cdef class PyArchive:
 
         cdef wrapper.search_iterator it = search.begin()
         while it != search.end():
-            yield it.get_url().decode('UTF-8')
+            yield it.get_path().decode('UTF-8')
             preincrement(it)
 
     def search(self, query: str, start: int = 0, end: int = 10) -> Generator[str, None, None]:
@@ -653,7 +653,7 @@ cdef class PyArchive:
 
         cdef wrapper.search_iterator it = search.begin()
         while it != search.end():
-            yield it.get_url().decode('UTF-8')
+            yield it.get_path().decode('UTF-8')
             preincrement(it)
 
     def get_estimated_search_results_count(self, query: str) -> int:


### PR DESCRIPTION
Hi,

This PR aims to fix #105.
I have changed `get_url()` to `get_path()` to ensure compatibility with the current `libzim` code, [which recently changed the function name](https://github.com/openzim/libzim/commit/6ffd9a53a817e0cb90b6ddacbf85be47ca33618f).