### PR TITLE
Keep up with libzim

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [push]
 
 env:
-  LIBZIM_VERSION: 2021-03-16
+  LIBZIM_VERSION: 2021-04-26
   LIBZIM_INCLUDE_PATH: include/zim
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   MAX_LINE_LENGTH: 88

--- a/libzim/wrapper.pxd
+++ b/libzim/wrapper.pxd
@@ -113,7 +113,7 @@ cdef extern from "zim/search_iterator.h" namespace "zim":
         search_iterator operator++()
         bint operator==(search_iterator)
         bint operator!=(search_iterator)
-        string get_url()
+        string get_path()
         string get_title()
 
 

--- a/libzim/wrapper.pyx
+++ b/libzim/wrapper.pyx
@@ -627,7 +627,7 @@ cdef class PyArchive:
 
         cdef wrapper.search_iterator it = search.begin()
         while it != search.end():
-            yield it.get_url().decode('UTF-8')
+            yield it.get_path().decode('UTF-8')
             preincrement(it)
 
     def search(self, query: str, start: int = 0, end: int = 10) -> Generator[str, None, None]:
@@ -653,7 +653,7 @@ cdef class PyArchive:
 
         cdef wrapper.search_iterator it = search.begin()
         while it != search.end():
-            yield it.get_url().decode('UTF-8')
+            yield it.get_path().decode('UTF-8')
             preincrement(it)
 
     def get_estimated_search_results_count(self, query: str) -> int:

--- a/tests/test_libzim_reader.py
+++ b/tests/test_libzim_reader.py
@@ -16,11 +16,11 @@ from libzim.reader import Archive
 ZIMS_DATA = {
     "blank.zim": {
         "filename": "blank.zim",
-        "filesize": 25789,
+        "filesize": 17660,
         "new_ns": True,
         "mutlipart": False,
         "zim_uuid": None,
-        "metadata_keys": [],
+        "metadata_keys": ["Counter"],
         "test_metadata": None,
         "test_metadata_value": None,
         "has_main_entry": False,


### PR DESCRIPTION
libzim master introduced a couple of changes requiring changes in pylibzim:
- search iterator's `get_url()` has been renamed `get_path()`
- Counter metadata is now automatically generated in libzim

Also updating the libzim version with download to test against in our workflow