### PR TITLE
Added getMetadataItem support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - v*
 
 env:
-  LIBZIM_VERSION: 7.0.0
+  LIBZIM_VERSION: 7.1.0
   LIBZIM_INCLUDE_PATH: include/zim
   TWINE_USERNAME: __token__
   TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [push]
 
 env:
-  LIBZIM_VERSION: 7.0.0
+  LIBZIM_VERSION: 7.1.0
   LIBZIM_INCLUDE_PATH: include/zim
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   PROFILE: 1
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo LIBZIM_EXT=so >> $GITHUB_ENV
           echo LIBZIM_RELEASE=libzim_linux-x86_64-$LIBZIM_VERSION >> $GITHUB_ENV
-          echo LIBZIM_LIBRARY_PATH=lib/x86_64-linux-gnu/libzim.so.7.0.0 >> $GITHUB_ENV
+          echo LIBZIM_LIBRARY_PATH=lib/x86_64-linux-gnu/libzim.so.7.1.0 >> $GITHUB_ENV
 
       - name: Cache libzim dylib & headers
         uses: actions/cache@master

--- a/libzim/libwrapper.h
+++ b/libzim/libwrapper.h
@@ -153,6 +153,7 @@ class Archive : public Wrapper<zim::Archive>
     }
     FORWARD(zim::size_type, getFilesize)
     FORWARD(std::string, getMetadata)
+    FORWARD(wrapper::Item, getMetadataItem)
     FORWARD(std::vector<std::string>, getMetadataKeys)
     FORWARD(zim::size_type, getEntryCount)
     FORWARD(zim::size_type, getAllEntryCount)

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -799,6 +799,11 @@ cdef class Archive:
         """List of Metadata keys present in this archive"""
         return [key.decode("UTF-8", "strict") for key in self.c_archive.getMetadataKeys()]
 
+    def get_metadata_item(self, name: str) -> Item:
+        """A Metadata's Item"""
+        cdef zim.Item item = move(self.c_archive.getMetadataItem(name.encode('UTF-8')))
+        return Item.from_item(move(item))
+
     def get_metadata(self, name: str) -> bytes:
         """A Metadata's content -> bytes
 

--- a/libzim/zim.pxd
+++ b/libzim/zim.pxd
@@ -138,6 +138,7 @@ cdef extern from "libwrapper.h" namespace "wrapper":
         Entry getEntryByTitle(string title) except +
 
         string getMetadata(string name) except +
+        Item getMetadataItem(string name) except +
         vector[string] getMetadataKeys() except +
 
         Entry getMainEntry() except +

--- a/tasks.py
+++ b/tasks.py
@@ -14,7 +14,7 @@ from invoke import task
 
 
 @task
-def download_libzim(c, version="7.0.0"):
+def download_libzim(c, version="7.1.0"):
     """download C++ libzim binary"""
 
     if platform.machine() != "x86_64" or platform.system() not in ("Linux", "Darwin"):

--- a/tests/test_libzim_reader.py
+++ b/tests/test_libzim_reader.py
@@ -190,6 +190,50 @@ ZIMS_DATA = {
         "test_redirect": "-/favicon",
         "test_redirect_to": "I/empty.png",
     },
+    "small.zim": {
+        "filename": "small.zim",
+        "filesize": 41155,
+        "new_ns": True,
+        "mutlipart": False,
+        "zim_uuid": "3581ae7eedd57e6cd2f1c0cab073643f",
+        "metadata_keys": [
+            "Counter",
+            "Creator",
+            "Date",
+            "Description",
+            "Illustration_48x48@1",
+            "Language",
+            "Publisher",
+            "Scraper",
+            "Tags",
+            "Title",
+        ],
+        "test_metadata": "Title",
+        "test_metadata_value": "Test ZIM file",
+        "has_main_entry": True,
+        "has_favicon_entry": True,
+        "has_fulltext_index": False,
+        "has_title_index": True,
+        "has_checksum": True,
+        "checksum": None,
+        "is_valid": True,
+        "entry_count": 2,
+        "all_entry_count": 16,
+        "article_count": 1,
+        "suggestion_string": None,
+        "suggestion_count": None,
+        "suggestion_result": None,
+        "search_string": None,
+        "search_count": None,
+        "search_result": None,
+        "test_path": "main.html",
+        "test_title": "Test ZIM file",
+        "test_mimetype": "text/html",
+        "test_size": 207,
+        "test_content_includes": "Test ZIM file",
+        "test_redirect": None,
+        "test_redirect_to": None,
+    },
 }
 
 
@@ -220,7 +264,7 @@ def all_zims(tmpdir_factory):
     libzim_urls = [
         f"https://github.com/kiwix/kiwix-lib/raw/master/test/data/{name}"
         for name in ("zimfile.zim", "example.zim", "corner_cases.zim")
-    ]
+    ] + ["https://github.com/openzim/zim-testing-suite/raw/main/data/nons/small.zim"]
 
     # download libzim tests
     for url in libzim_urls:
@@ -313,6 +357,9 @@ def test_reader_metadata(
     assert zim.metadata_keys == metadata_keys
     if test_metadata:
         assert zim.get_metadata(test_metadata).decode("UTF-8") == test_metadata_value
+        item = zim.get_metadata_item(test_metadata)
+        assert item.mimetype == "text/plain"
+        assert item.size > 1
 
 
 @pytest.mark.parametrize(
@@ -346,6 +393,8 @@ def test_reader_main_favicon_entries(
         if new_ns:
             assert zim.get_illustration_item().path == "Illustration_48x48@1"
             assert zim.get_illustration_sizes() == {48}
+
+            assert zim.get_metadata_item("Illustration_48x48@1").mimetype == "image/png"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Updated test and release workflows to use libzim 7.1.0
added `get_metadata_item()` on Archive to match `getMetadataItem()`.
Improved existing tests to test it.
Added a new ZIM from zim-testing-suite to test for Illustration's mimetype