### PR TITLE
python3.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         # TODO: expand this to cross-platform builds (see V2 approach below)
         # os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build cython and sdist
         run: |
-          pip install --upgrade "cython>=0.29.22,<3.0" setuptools pip wheel
+          pip install --upgrade "cython>=0.29.26,<3.0" setuptools pip wheel
           python3 setup.py build_ext --rpath $RPATH
           if [[  "${{ matrix.python-version }}" == "3.6" ]]
           then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         # TODO: expand this once macos and windows libzim releases become available
         # os: [ubuntu-latest, windows-latest, macos-10.15]
         # alternatively we can compile libzim in docker and use the container as an action
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build cython, sdist, and bdist_wheel
         run: |
-          pip install --upgrade pip install "cython>=0.29.22,<3.0" setuptools pip wheel
+          pip install --upgrade pip install "cython>=0.29.26,<3.0" setuptools pip wheel
           python3 setup.py build_ext --inplace
           python3 setup.py sdist bdist_wheel
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools >= 35.0.2", "wheel >= 0.29.0", "twine", "cython >= 0.29.22,<3.0" ]
+requires = [ "setuptools >= 35.0.2", "wheel >= 0.29.0", "twine", "cython >= 0.29.26,<3.0" ]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     #Typing :: Typed
     License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)
     Operating System :: OS Independent


### PR DESCRIPTION
- update cython 0.29.22 → 0.29.23 (first supporting 3.10)
- add test and build for 3.10

It seems like tests are not setups to run on PRs, [but they passed on my fork](https://github.com/jc-louis/python-libzim/runs/4948807987?check_suite_focus=true).