### PR TITLE
Use libzim 7.2.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - v*
 
 env:
-  LIBZIM_VERSION: 7.1.0
+  LIBZIM_VERSION: 7.2.2
   LIBZIM_INCLUDE_PATH: include/zim
   TWINE_USERNAME: __token__
   TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build cython and sdist
         run: |
-          pip install --upgrade "cython>=0.29.26,<3.0" setuptools pip wheel
+          pip install --upgrade "cython>=0.29.28,<3.0" setuptools pip wheel
           python3 setup.py build_ext --rpath $RPATH
           if [[  "${{ matrix.python-version }}" == "3.6" ]]
           then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 on: [push]
 
 env:
-  LIBZIM_VERSION: 7.1.0
+  LIBZIM_VERSION: 7.2.2
   LIBZIM_INCLUDE_PATH: include/zim
   CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
   PROFILE: 1
@@ -56,7 +56,7 @@ jobs:
         run: |
           echo LIBZIM_EXT=so >> $GITHUB_ENV
           echo LIBZIM_RELEASE=libzim_linux-x86_64-$LIBZIM_VERSION >> $GITHUB_ENV
-          echo LIBZIM_LIBRARY_PATH=lib/x86_64-linux-gnu/libzim.so.7.1.0 >> $GITHUB_ENV
+          echo LIBZIM_LIBRARY_PATH=lib/x86_64-linux-gnu/libzim.so.7.2.2 >> $GITHUB_ENV
 
       - name: Cache libzim dylib & headers
         uses: actions/cache@master
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build cython, sdist, and bdist_wheel
         run: |
-          pip install --upgrade pip install "cython>=0.29.26,<3.0" setuptools pip wheel
+          pip install --upgrade pip install "cython>=0.29.28,<3.0" setuptools pip wheel
           python3 setup.py build_ext --inplace
           python3 setup.py sdist bdist_wheel
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* getMetadataItem support (#127)
-* Added Python3.10 Support
+* `Archive.get_metadata_item()` (#127)
+* Python 3.10 Support
 
 ### Changed
 
+* using libzim 7.2.2
+  * RuntimeError exception is now raises on invalid/duplicate entries
 * Allow setting mimetype for metadata
 * Updated Cython to 0.29.28
 * Fixed `Archive.filesize` (#137)
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2021-10-09
 
-* using libzim 7.x
+* using libzim 7.0.0
 * Python 3.9 support
 * [breaking] Using new libzim 7-based API for both reader and writer
   * No more namespaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,29 @@
-## 1.1.0
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* getMetadataItem support (#127)
+* Added Python3.10 Support
+
+### Changed
 
 * Allow setting mimetype for metadata
-* added getMetadataItem support (#127)
-* skip cython on setup.py clean (#131)
-* OFFLINE environ skips network-using tests (#132)
-* Added Python3.10 Support
-* Updated Cython to 0.29.26
+* Updated Cython to 0.29.28
 * Fixed `Archive.filesize` (#137)
 
-## 1.0.0
+### Removed
+
+* skip cython on setup.py clean (#131)
+* OFFLINE environ skips network-using tests (#132)
+
+## [1.0.0] - 2021-10-09
 
 * using libzim 7.x
 * Python 3.9 support
@@ -21,7 +36,7 @@
 * macOS releases are signed and notarized
 * Early-failure on invalid destination ZIM path
 
-## 0.0.4
+## [0.0.4]
 
 * added compression argument to Creator to set compression algorithm (libzim.writer.Compression)
 * Creator positional arguments order changed: min_chunk_size moved after compression
@@ -31,11 +46,11 @@
 * Fixed using `get_filename()` (#71)
 * using libzim 6.1.8
 
-## 0.0.3.post0
+## [0.0.3.post0]
 
 * fixed access to bundled libzim on macOS (missing rpath)
 
-## 0.0.3
+## [0.0.3]
 
 * [reader] fixed `main_page` retrieval
 * [reader] provide access to redirect target via `get_redirect_article()` (#51)
@@ -64,7 +79,7 @@
 * building with Cython 0.29.20+
 * using libzim 6.1.7
 
-## 0.0.2
+## [0.0.2]
 
 * initial release
 * using libzim 6.1.6

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -304,6 +304,8 @@ cdef class _Creator:
             Raises
             ------
                 RuntimeError
+                    If an Item exists with the same path
+                RuntimeError
                     If the ZimCreator was already finalized"""
         if not self._started:
             raise RuntimeError("Creator not started")
@@ -317,7 +319,12 @@ cdef class _Creator:
     def add_metadata(self, str name: str, bytes content: bytes, str mimetype: str):
         """Add metadata entry to Archive
 
-        https://wiki.openzim.org/wiki/Metadata"""
+            https://wiki.openzim.org/wiki/Metadata
+
+            Raises
+            ------
+                RuntimeError
+                    If a Metadata exists with the same name"""
         if not self._started:
             raise RuntimeError("Creator not started")
 
@@ -331,6 +338,11 @@ cdef class _Creator:
         """Add redirection entry to Archive
 
             https://wiki.openzim.org/wiki/ZIM_file_format#Redirect_Entry
+
+            Raises
+            ------
+                RuntimeError
+                    If a Rediction exists with the same path
             """
         if not self._started:
             raise RuntimeError("Creator not started")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = [ "setuptools >= 35.0.2", "wheel >= 0.29.0", "twine", "cython >= 0.29.26,<3.0" ]
+requires = [ "setuptools >= 35.0.2", "wheel >= 0.29.0", "twine", "cython >= 0.29.28,<3.0" ]
 build-backend = "setuptools.build_meta"
 
 [tool.black]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ invoke>=1.5,<2.0
 coverage>=5.0,<7.0
 pytest>=6.2,<7.0
 pytest-cov>=2.10,<4.0
-Cython>=0.29.26
+Cython>=0.29.28

--- a/tasks.py
+++ b/tasks.py
@@ -14,7 +14,7 @@ from invoke import task
 
 
 @task
-def download_libzim(c, version="7.1.0"):
+def download_libzim(c, version="7.2.2"):
     """download C++ libzim binary"""
 
     if platform.machine() != "x86_64" or platform.system() not in ("Linux", "Darwin"):


### PR DESCRIPTION
- Use libzim 7.2.1 for release and ci workflows
- Updated tests to new libzim 7.2.1 behavior (exceptions on duplicates)
- Use latest Cython version