### PR TITLE
Forwarding libzim exception in addIllustration()

### DIFF
--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -287,7 +287,12 @@ cdef class _Creator:
     def add_illustration(self, int size: pyint, content: bytes):
         """Add a PNG illustration to Archive
 
-            https://wiki.openzim.org/wiki/Metadata"""
+            https://wiki.openzim.org/wiki/Metadata
+
+            Raises
+            ------
+                RuntimeError
+                    If an Illustration exists with the same size"""
         cdef string _content = content
         self.c_creator.addIllustration(size, _content)
 

--- a/libzim/zim.pxd
+++ b/libzim/zim.pxd
@@ -64,7 +64,7 @@ cdef extern from "zim/writer/creator.h" namespace "zim::writer":
         void addRedirection(string path, string title, string targetpath, map[HintKeys, uint64_t] hints) nogil except +
         void finishZimCreation() nogil except +
         void setMainPath(string mainPath)
-        void addIllustration(unsigned int size, string content)
+        void addIllustration(unsigned int size, string content) nogil except +
 
 cdef extern from "zim/search.h" namespace "zim":
     cdef cppclass Query:

--- a/tests/test_libzim_creator.py
+++ b/tests/test_libzim_creator.py
@@ -433,8 +433,8 @@ def test_creator_metadata_overwrite(fpath, lipsum_item, favicon_data):
 
         c.add_illustration(48, favicon_data)
         # this currently segfaults but it should not
-        # with pytest.raises(RuntimeError, match="Impossible to add"):
-        #     c.add_illustration(48, favicon_data)
+        with pytest.raises(RuntimeError, match="Impossible to add"):
+            c.add_illustration(48, favicon_data)
     zim = Archive(fpath)
     assert zim.get_metadata("Key").decode("UTF-8") == "first"
 


### PR DESCRIPTION
@mgautierfr I've set `nogil` as well since `addMetadata()` has it.

Fixes #141 
