### PR TITLE
Add `printVersions()` and `getVersions()`.

### DIFF
--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -1266,12 +1266,13 @@ cdef class Version:
     def print_version(out: Union[sys.stdout, sys.stderr] = sys.stdout):
         versions = Version.get_versions()
         for i, version in enumerate(versions):
-            output = ""
+            prefix = ""
             if i > 0:
-                output +=  "+ "
-            output += version[0].decode("utf-8") 
-            output += " "
-            output += version[1].decode("utf-8") 
+                prefix=  "+"
+            output = "{prefix} {version_name} {version_value}".format(
+                    prefix=prefix, 
+                    version_name=version[0].decode("utf-8"), 
+                    version_value=version[1].decode("utf-8"))
             print(output, file=out)
 
 

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -1259,7 +1259,7 @@ version = create_module(version_module_name, version_module_doc, version_public_
 cdef class Version:
     __module__ = version_module_name
     @staticmethod
-    def get_versions() -> [(string, string)]:
+    def get_versions() -> [(bytes, bytes)]:
         return zim.getVersions()
 
     @staticmethod

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -1243,6 +1243,37 @@ suggestion_public_objects = [
 ]
 suggestion = create_module(suggestion_module_name, suggestion_module_doc, suggestion_public_objects)
 
+version_module_doc = """libzim version module
+- Get versions of libzim.
+- Print version of libzim.
+
+Usage:
+    versions = Version.get_versions()
+    Version.print_version()"""
+version_public_objects = [
+    Version,
+]
+version_module_name = f"{__name__}.version"
+version = create_module(version_module_name, version_module_doc, version_public_objects)
+
+cdef class Version:
+    __module__ = version_module_name
+    @staticmethod
+    def get_versions() -> [(string, string)]:
+        return zim.getVersions()
+
+    @staticmethod
+    def print_version(out: Union[sys.stdout, sys.stderr] = sys.stdout):
+        versions = Version.get_versions()
+        for i, version in enumerate(versions):
+            output = ""
+            if i > 0:
+                output +=  "+ "
+            output += version[0].decode("utf-8") 
+            output += " "
+            output += version[1].decode("utf-8") 
+            print(output, file=out)
+
 
 
 class ModuleLoader(importlib.abc.Loader):
@@ -1253,7 +1284,8 @@ class ModuleLoader(importlib.abc.Loader):
             'libzim.writer': writer,
             'libzim.reader': reader,
             'libzim.search': search,
-            'libzim.suggestion': suggestion
+            'libzim.suggestion': suggestion,
+            'libzim.version': version 
         }.get(spec.name, None)
 
     @staticmethod
@@ -1272,5 +1304,5 @@ class ModuleFinder(importlib.abc.MetaPathFinder):
 # register finder for our submodules
 sys.meta_path.insert(0, ModuleFinder())
 
-__all__ = ["writer", "reader", "search", "suggestion"]
+__all__ = ["writer", "reader", "search", "suggestion", "version"]
 

--- a/libzim/zim.pxd
+++ b/libzim/zim.pxd
@@ -22,6 +22,7 @@ from libc.stdint cimport uint32_t, uint64_t
 from libcpp cimport bool
 from libcpp.map cimport map
 from libcpp.memory cimport shared_ptr
+from libcpp.pair cimport pair
 from libcpp.set cimport set
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -218,3 +219,6 @@ cdef extern from "libwrapper.h" namespace "wrapper":
         SuggestionIterator begin()
         SuggestionIterator end()
         int size()
+
+cdef extern from "zim/version.h" namespace "zim":
+    cdef vector[pair[string, string]] getVersions()

--- a/tests/test_libzim_reader.py
+++ b/tests/test_libzim_reader.py
@@ -358,7 +358,6 @@ def test_reader_archive(all_zims, filename, filesize, new_ns, mutlipart, zim_uui
 def test_reader_metadata(
     all_zims, filename, metadata_keys, test_metadata, test_metadata_value
 ):
-
     zim = Archive(all_zims / filename)
 
     # make sure metadata_keys is empty

--- a/tests/test_libzim_version.py
+++ b/tests/test_libzim_version.py
@@ -1,0 +1,20 @@
+import sys
+
+from libzim.version import Version
+
+
+def test_get_verions():
+    versions = Version.get_versions()
+    assert len(versions) != 0
+
+
+def test_print_verion_with_stdout(capfd):
+    Version.print_version()
+    stdout, stderr = capfd.readouterr()
+    assert len(stdout) != 0
+
+
+def test_print_verion_with_stderr(capfd):
+    Version.print_version(sys.stderr)
+    stdout, stderr = capfd.readouterr()
+    assert len(stderr) != 0


### PR DESCRIPTION
Fix: #148 