### PR TITLE
Introducing printVersions() and getVersions()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* `version` module with
+  * `version.get_versions()` returning an OrderedDict of library:version inclusing libzim
+  * `version.print_versions()` print it on stdout (or another fd)
+  * `version.get_libzim_version()` returns the libzim version only
+
 ## [2.1.0] - 2022-12-06
 
 ### Added

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -39,6 +39,7 @@ import os
 import pathlib
 import sys
 import traceback
+from collections import OrderedDict
 from types import ModuleType
 from typing import Dict, Generator, Iterator, List, Optional, Set, Tuple, Union
 from uuid import UUID
@@ -1244,37 +1245,46 @@ suggestion_public_objects = [
 suggestion = create_module(suggestion_module_name, suggestion_module_doc, suggestion_public_objects)
 
 version_module_doc = """libzim version module
-- Get versions of libzim.
-- Print version of libzim.
+- Get version of libzim and its dependencies
+- Print version of libzim and its dependencies
+- Get libzim version
 
 Usage:
-    versions = Version.get_versions()
-    Version.print_version()"""
+    from libzim.version import get_libzim_version, get_versions, print_versions
+    major, minor, patch = get_libzim_version().split(".", 2)
+
+    for dependency, version in get_versions().items():
+        print(f"- {dependency}={version}")
+
+    print_versions()"""
+
+
+def print_versions(out: Union[sys.stdout, sys.stderr] = sys.stdout):
+    """print libzim and its dependencies list with their versions"""
+    for library, version in get_versions().items():
+        prefix = "" if library == "libzim" else "+ "
+        print(f"{prefix}{library} {version}", file=out or sys.stdout)
+
+
+def get_versions() -> OrderedDict[str, str]:
+    """ library: version mapping. Always includes `libzim`"""
+    versions = zim.getVersions()
+    return OrderedDict({
+        library.decode("UTF-8"): version.decode("UTF-8")
+        for library, version in versions
+    })
+
+def get_libzim_version() -> str:
+    """libzim version string"""
+    return get_versions()["libzim"]
+
 version_public_objects = [
-    Version,
+    get_libzim_version,
+    get_versions,
+    print_versions,
 ]
 version_module_name = f"{__name__}.version"
 version = create_module(version_module_name, version_module_doc, version_public_objects)
-
-cdef class Version:
-    __module__ = version_module_name
-    @staticmethod
-    def get_versions() -> [(bytes, bytes)]:
-        return zim.getVersions()
-
-    @staticmethod
-    def print_version(out: Union[sys.stdout, sys.stderr] = sys.stdout):
-        versions = Version.get_versions()
-        for i, version in enumerate(versions):
-            prefix = ""
-            if i > 0:
-                prefix=  "+"
-            output = "{prefix} {version_name} {version_value}".format(
-                    prefix=prefix, 
-                    version_name=version[0].decode("utf-8"), 
-                    version_value=version[1].decode("utf-8"))
-            print(output, file=out)
-
 
 
 class ModuleLoader(importlib.abc.Loader):

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -1266,12 +1266,13 @@ cdef class Version:
     def print_version(out: Union[sys.stdout, sys.stderr] = sys.stdout):
         versions = Version.get_versions()
         for i, version in enumerate(versions):
-            output = ""
+            prefix = ""
             if i > 0:
-                output +=  "+ "
-            output += version[0].decode("utf-8") 
-            output += " "
-            output += version[1].decode("utf-8") 
+                prefix=  "+"
+            output = "{prefix} {version_name} {version_value}".format(
+                    prefix=prefix, 
+                    version_name=version[0].decode("utf-8"), 
+                    version_value=version[1].decode("utf-8"))
             print(output, file=out)
 
 

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -1259,7 +1259,7 @@ version = create_module(version_module_name, version_module_doc, version_public_
 cdef class Version:
     __module__ = version_module_name
     @staticmethod
-    def get_versions() -> [(string, string)]:
+    def get_versions() -> [(bytes, bytes)]:
         return zim.getVersions()
 
     @staticmethod

--- a/libzim/libzim.pyx
+++ b/libzim/libzim.pyx
@@ -1243,6 +1243,37 @@ suggestion_public_objects = [
 ]
 suggestion = create_module(suggestion_module_name, suggestion_module_doc, suggestion_public_objects)
 
+version_module_doc = """libzim version module
+- Get versions of libzim.
+- Print version of libzim.
+
+Usage:
+    versions = Version.get_versions()
+    Version.print_version()"""
+version_public_objects = [
+    Version,
+]
+version_module_name = f"{__name__}.version"
+version = create_module(version_module_name, version_module_doc, version_public_objects)
+
+cdef class Version:
+    __module__ = version_module_name
+    @staticmethod
+    def get_versions() -> [(string, string)]:
+        return zim.getVersions()
+
+    @staticmethod
+    def print_version(out: Union[sys.stdout, sys.stderr] = sys.stdout):
+        versions = Version.get_versions()
+        for i, version in enumerate(versions):
+            output = ""
+            if i > 0:
+                output +=  "+ "
+            output += version[0].decode("utf-8") 
+            output += " "
+            output += version[1].decode("utf-8") 
+            print(output, file=out)
+
 
 
 class ModuleLoader(importlib.abc.Loader):
@@ -1253,7 +1284,8 @@ class ModuleLoader(importlib.abc.Loader):
             'libzim.writer': writer,
             'libzim.reader': reader,
             'libzim.search': search,
-            'libzim.suggestion': suggestion
+            'libzim.suggestion': suggestion,
+            'libzim.version': version 
         }.get(spec.name, None)
 
     @staticmethod
@@ -1272,5 +1304,5 @@ class ModuleFinder(importlib.abc.MetaPathFinder):
 # register finder for our submodules
 sys.meta_path.insert(0, ModuleFinder())
 
-__all__ = ["writer", "reader", "search", "suggestion"]
+__all__ = ["writer", "reader", "search", "suggestion", "version"]
 

--- a/libzim/zim.pxd
+++ b/libzim/zim.pxd
@@ -22,6 +22,7 @@ from libc.stdint cimport uint32_t, uint64_t
 from libcpp cimport bool
 from libcpp.map cimport map
 from libcpp.memory cimport shared_ptr
+from libcpp.pair cimport pair
 from libcpp.set cimport set
 from libcpp.string cimport string
 from libcpp.vector cimport vector
@@ -218,3 +219,6 @@ cdef extern from "libwrapper.h" namespace "wrapper":
         SuggestionIterator begin()
         SuggestionIterator end()
         int size()
+
+cdef extern from "zim/version.h" namespace "zim":
+    cdef vector[pair[string, string]] getVersions()

--- a/tests/test_libzim_reader.py
+++ b/tests/test_libzim_reader.py
@@ -358,7 +358,6 @@ def test_reader_archive(all_zims, filename, filesize, new_ns, mutlipart, zim_uui
 def test_reader_metadata(
     all_zims, filename, metadata_keys, test_metadata, test_metadata_value
 ):
-
     zim = Archive(all_zims / filename)
 
     # make sure metadata_keys is empty

--- a/tests/test_libzim_reader.py
+++ b/tests/test_libzim_reader.py
@@ -358,6 +358,7 @@ def test_reader_archive(all_zims, filename, filesize, new_ns, mutlipart, zim_uui
 def test_reader_metadata(
     all_zims, filename, metadata_keys, test_metadata, test_metadata_value
 ):
+
     zim = Archive(all_zims / filename)
 
     # make sure metadata_keys is empty

--- a/tests/test_libzim_version.py
+++ b/tests/test_libzim_version.py
@@ -1,0 +1,20 @@
+import sys
+
+from libzim.version import Version
+
+
+def test_get_verions():
+    versions = Version.get_versions()
+    assert len(versions) != 0
+
+
+def test_print_verion_with_stdout(capfd):
+    Version.print_version()
+    stdout, stderr = capfd.readouterr()
+    assert len(stdout) != 0
+
+
+def test_print_verion_with_stderr(capfd):
+    Version.print_version(sys.stderr)
+    stdout, stderr = capfd.readouterr()
+    assert len(stderr) != 0

--- a/tests/test_libzim_version.py
+++ b/tests/test_libzim_version.py
@@ -1,20 +1,33 @@
+import re
 import sys
 
-from libzim.version import Version
+from libzim.version import get_libzim_version, get_versions, print_versions
 
 
-def test_get_verions():
-    versions = Version.get_versions()
-    assert len(versions) != 0
-
-
-def test_print_verion_with_stdout(capfd):
-    Version.print_version()
-    stdout, stderr = capfd.readouterr()
+def test_version_print_version_with_stdout(capsys):
+    print_versions()
+    print("", file=sys.stdout, flush=True)
+    stdout, stderr = capsys.readouterr()
     assert len(stdout) != 0
 
 
-def test_print_verion_with_stderr(capfd):
-    Version.print_version(sys.stderr)
-    stdout, stderr = capfd.readouterr()
+def test_version_print_version_with_stderr(capsys):
+    print_versions(sys.stderr)
+    print("", file=sys.stderr, flush=True)
+    stdout, stderr = capsys.readouterr()
     assert len(stderr) != 0
+
+
+def test_get_versions():
+    versions = get_versions()
+    assert versions
+    assert "libzim" in versions
+    assert len(versions.keys()) > 1
+    for library, version in versions.items():
+        assert isinstance(library, str)
+        assert isinstance(version, str)
+
+
+def test_get_libzim_version():
+    # libzim uses semantic versioning
+    assert re.match(r"\d+\.\d+\.\d+", get_libzim_version())


### PR DESCRIPTION
This is a follow-up of #158 and fixes #148 as well.

This includes @FledgeXu's PR but improves the Python API

```
- Better docstring
- Refactored to uses module functions instead of (useless) Version class
- Changed get_versions() to return an OrderedDict for easier in-python use
- Added get_libzim_version() shortcut
- Simplified print_version's code
- Fixed print_version tests (use flush so we're sure its present when checking)
- Changed tests for get_versions and get_libzim_version
```