### PR TITLE
platform only checked if downloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Build with (and target) libzim 8.2.1
+- Fixed setup checking download platform even when using own libzim (not downloading)
 
 ## Removed
 

--- a/setup.py
+++ b/setup.py
@@ -149,6 +149,7 @@ class Config:
 
     def download_to_dest(self):
         """download expected libzim binary into libzim/ and libzim/include/ folders"""
+        self.check_platform()
         if self.wants_universal:
             folders = {}
             for arch in self.supported_platforms["Darwin"]:
@@ -474,7 +475,6 @@ class DownloadLibzim(Command):
         ...
 
     def run(self):
-        config.check_platform()
         config.download_to_dest()
 
 
@@ -494,7 +494,6 @@ class LibzimClean(Command):
 if len(sys.argv) == 2 and sys.argv[1] in config.buildless_commands:
     ext_modules = None
 else:
-    config.check_platform()
     ext_modules = get_cython_extension()
 
 setup(


### PR DESCRIPTION
We were incorrectly checking the platform unconditionally while this is only relevant to halt the setup when we'll download libzim binary (and there wont be a matching file to download)