### PR TITLE
dont skip musllinux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,9 @@ pythonpath = ["."]
 
 [tool.cibuildwheel]
 build = "*"
-# disabling musllinux until https://github.com/kiwix/kiwix-build/issues/585
 # disabling windows until hhttps://github.com/kiwix/kiwix-build/issues/466
 # disabling PyPy due to 2 failing tests
-skip = "pp* *musllinux* *-win*"
+skip = "pp* *-win*"
 
 test-requires = ["pytest"]
 test-command = "py.test {project}/tests/"


### PR DESCRIPTION
musl PR history rewrite kept the ignore rule regarding musllinux so it was not included in 3.3.0