### PR TITLE
Use new name for manylinux libzim archive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -149,7 +149,7 @@ class Config:
 
         variant = ""
         if self.platform == "Linux":
-            variant = "-musl" if self.is_musl else "-bionic"
+            variant = "-musl" if self.is_musl else "-manylinux"
 
         if self.is_latest_nightly:
             version_suffix = ""


### PR DESCRIPTION
libzim is now build on manylinux instead of bionic.
Archive name has been changed.