### PR TITLE
Supply mandatory metadata in writer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,12 +117,16 @@ with Creator("test.zim").config_indexing(True, "eng") as creator:
     creator.set_mainpath("home")
     creator.add_item(item)
     creator.add_item(item2)
+    illustration = open("icon48x48.png", mode="rb").read()
+    creator.add_illustration(48, illustration)
     for name, value in {
         "creator": "python-libzim",
         "description": "Created in python",
         "name": "my-zim",
         "publisher": "You",
         "title": "Test ZIM",
+        "language": "en",
+        "date": "2024-06-30"
     }.items():
 
         creator.add_metadata(name.title(), value)

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ with Creator("test.zim").config_indexing(True, "eng") as creator:
     creator.set_mainpath("home")
     creator.add_item(item)
     creator.add_item(item2)
-    illustration = open("icon48x48.png", mode="rb").read()
+    illustration = pathlib.Path("icon48x48.png").read_bytes()
     creator.add_illustration(48, illustration)
     for name, value in {
         "creator": "python-libzim",
@@ -125,7 +125,7 @@ with Creator("test.zim").config_indexing(True, "eng") as creator:
         "name": "my-zim",
         "publisher": "You",
         "title": "Test ZIM",
-        "language": "en",
+        "language": "eng",
         "date": "2024-06-30"
     }.items():
 


### PR DESCRIPTION
A zim file has certain mandatory requirements in the metadata; for example, Language, Date, and Illustration must be present. If they aren't, then some ZIM reader apps (such as Kiwix for iOS) will refuse to open the zim file. So, add these mandatory pieces to the example code in the readme, so that if you generate a zim file by following the example code, it will be valid.
(Discovered in https://github.com/kiwix/kiwix-apple/issues/842)