### PR TITLE
Using ubuntu24.04 in CI as ubuntu-20.04 is about to be removed (2025-04-01)

### DIFF
--- a/.github/workflows/CI-wheels.yaml
+++ b/.github/workflows/CI-wheels.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, windows-2022, ubuntu-20.04]
+        os: [macos-13, windows-2022, ubuntu-24.04]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/Publish.yaml
+++ b/.github/workflows/Publish.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-13, windows-2022]
+        os: [ubuntu-24.04, macos-13, windows-2022]
 
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
           path: dist
       - uses: actions/download-artifact@v4
         with:
-          name: wheels-ubuntu-20.04
+          name: wheels-ubuntu-24.04
           path: dist
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
This is assuming that Linux wheels are built on manylinux images and should not depend on the host