### PR TITLE
Add multi-archive search support and identifiable search results

### DIFF
--- a/libzim/search.pyi
+++ b/libzim/search.pyi
@@ -5,16 +5,34 @@ from typing import Self
 
 from libzim.reader import Archive
 
+
 class Query:
+
     def set_query(self, query: str) -> Self: ...
 
+
+class SearchResult:
+
+    archive: Archive
+    path: str
+
+
 class SearchResultSet:
-    def __iter__(self) -> Iterator[str]: ...
+
+    def __iter__(self) -> Iterator[SearchResult]: ...
+
 
 class Search:
+
     def getEstimatedMatches(self) -> int: ...  # noqa: N802
+
     def getResults(self, start: int, count: int) -> SearchResultSet: ...  # noqa: N802
 
+
 class Searcher:
-    def __init__(self, archive: Archive) -> None: ...
+
+    def __init__(self) -> None: ...
+
+    def addArchive(self, archive: Archive) -> None: ...
+
     def search(self, query: Query) -> Search: ...


### PR DESCRIPTION
Issue : #230  As highlighted by https://github.com/openzim/python-libzim/pull/229, Searcher's getResults() only yields result's entry path. while convenient for single-archive search, it prevents implementing multi-ZIM search as results would only be path strings from multiple ZIMs.

We should then implement multiple ZIM search properly by

Binding addArche to Searcher (ref impl in https://github.com/openzim/python-libzim/pull/229)
Change Searcher API so that results can be identified                                                                                                                                        

--------------------------------------------------------------------------------------------------------------------------------------

 # Our Changes :

# Allowing multiple archives to be bound to a Searcher

    1. Added a _archives list to track all registered archives.

     2. Introduced Searcher.addArchive(archive: Archive) method to register additional archives.

     3. Searcher.search(query) now searches across all bound archives.

# Returning identifiable search results

        1. Introduced a new class: SearchResult containing:

                  class SearchResult:
                        archive: Archive
                        path: str

        2. Updated SearchResultSet.__iter__() to yield SearchResult objects instead of strings.

       3. Results are now unambiguous and include both archive and entry path.

# Updated type hints in search.pyi

       1. SearchResultSet.__iter__() now returns Iterator[SearchResult]

       2. Searcher.addArchive() is added to type hints

       3. Python API fully matches the new Cython implementation.

----------------------------------------------------------------------------------------------------------------------------------

# Benefits : 

  1.Enables multi-ZIM search

  2.Ensures search results are uniquely identifiable

  3.Clean, maintainable API, consistent with libzim C++ internals

  4.Future-proof for features like ranking, filtering, and deduplication across multiple archives.

----------------------------------------------------------------------------------------------------------------------------------

# Backward Compatibility :

  1.The API change from Iterator[str] → Iterator[SearchResult] is intentional to support multi-ZIM search.

  2.Users can still access the path via result.path to simplify migration.

------------------------------------------------------------------------------------------------------------------------------------